### PR TITLE
Add install of mkl_def.2.dll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+<!---
+  SPDX-FileCopyrightText: 2023 SAP SE
+
+  SPDX-License-Identifier: Apache-2.0
+
+  This file is part of FEDEM - https://openfedem.org
+--->
+
+# FEDEM solvers Changelog
+
+## [fedem-8.0.1] (2024-01-25)
+
+### :rocket: Added
+
+- The frequency domain solution methods are reinstated,
+  using the FFTPACK 5.1 library which now is embedded in this repository.
+
+### :bug: Fixed
+
+- (Cosmetic) A newline follows the object description in the frs-file header.
+- Direct curve export from the dynamics solver does not work,
+  due do the issue [SAP/fedem-gui#5](https://github.com/SAP/fedem-gui/issues/5).
+
+## fedem-8.0.0 (2023-12-21)
+
+### :rocket: Added
+
+- First open source version of the FEDEM solvers, including a Python API
+
+[fedem-8.0.1]: https://github.com/SAP/fedem-gui/compare/fedem-8.0.0...fedem-8.0.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,8 @@ if ( WIN AND DEFINED ENV{MKLROOT} )
   if ( FTENV_VERBOSE )
     message ( STATUS "Installing MKL redistributables from ${MKL_PATH} to ${CMAKE_INSTALL_PREFIX}" )
   endif ( FTENV_VERBOSE )
-  set ( MKL_REDIST ${MKL_PATH}/mkl_core.2.dll ${MKL_PATH}/mkl_avx2.2.dll
-                   ${MKL_PATH}/mkl_vml_avx2.2.dll ${MKL_PATH}/mkl_intel_thread.2.dll )
+  set ( MKL_REDIST ${MKL_PATH}/mkl_core.2.dll ${MKL_PATH}/mkl_def.2.dll
+                   ${MKL_PATH}/mkl_avx2.2.dll ${MKL_PATH}/mkl_vml_avx2.2.dll
+                   ${MKL_PATH}/mkl_intel_thread.2.dll )
   install ( FILES ${MKL_REDIST} DESTINATION "${CMAKE_INSTALL_PREFIX}/bin" )
 endif ( WIN AND DEFINED ENV{MKLROOT} )

--- a/src/Doxyfile.solver
+++ b/src/Doxyfile.solver
@@ -775,7 +775,6 @@ INPUT                   = src/vpmSolver \
                           src/vpmSolver/vpmSolverTests \
                           src/vpmReducer \
                           src/vpmReducer/vpmReducerTests \
-                          src/pFUnitExtraArg.f90 \
                           src/vpmCommon \
                           src/vpmCommon/vpmLinAlg \
                           src/vpmStress/displacementModule.f90 \
@@ -784,23 +783,24 @@ INPUT                   = src/vpmSolver \
                           src/vpmUtilities \
                           src/FemLib/beam.f \
                           src/FemLib/beamaux.f \
-                          fedem_foundation/src/gtest.h \
-                          fedem_foundation/src/FFrLib \
-                          fedem_foundation/src/FFaLib/FFaAlgebra \
-                          fedem_foundation/src/FFaLib/FFaCmdLineArg \
-                          fedem_foundation/src/FFaLib/FFaDefinitions \
-                          fedem_foundation/src/FFaLib/FFaDynCalls/FFaDynCB.H \
-                          fedem_foundation/src/FFaLib/FFaPatterns/FFaGenericFactory.H \
-                          fedem_foundation/src/FFaLib/FFaPatterns/FFaSingelton.H \
-                          fedem_foundation/src/FFaLib/FFaOperation \
-                          fedem_foundation/src/FFaLib/FFaOS \
-                          fedem_foundation/src/FFaLib/FFaString \
-                          fedem_foundation/src/FFaFunctionLib \
-                          fedem_foundation/src/FFaMathExpr \
-                          fedem_foundation/src/FFpLib/FFpCurveData \
-                          fedem_foundation/src/FFpLib/FFpExport \
-                          fedem_foundation/src/FiDeviceFunctions \
-                          fedem_foundation/src/FiUserElmPlugin
+                          fedem-foundation/pFUnit/pFUnitExtraArg.f90 \
+                          fedem-foundation/src/gtest.h \
+                          fedem-foundation/src/FFrLib \
+                          fedem-foundation/src/FFaLib/FFaAlgebra \
+                          fedem-foundation/src/FFaLib/FFaCmdLineArg \
+                          fedem-foundation/src/FFaLib/FFaDefinitions \
+                          fedem-foundation/src/FFaLib/FFaDynCalls/FFaDynCB.H \
+                          fedem-foundation/src/FFaLib/FFaPatterns/FFaGenericFactory.H \
+                          fedem-foundation/src/FFaLib/FFaPatterns/FFaSingelton.H \
+                          fedem-foundation/src/FFaLib/FFaOperation \
+                          fedem-foundation/src/FFaLib/FFaOS \
+                          fedem-foundation/src/FFaLib/FFaString \
+                          fedem-foundation/src/FFaFunctionLib \
+                          fedem-foundation/src/FFaMathExpr \
+                          fedem-foundation/src/FFpLib/FFpCurveData \
+                          fedem-foundation/src/FFpLib/FFpExport \
+                          fedem-foundation/src/FiDeviceFunctions \
+                          fedem-foundation/src/FiUserElmPlugin
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -825,7 +825,7 @@ INPUT_ENCODING         = UTF-8
 # *.m, *.markdown, *.md, *.mm, *.dox, *.py, *.pyw, *.f90, *.f, *.for, *.tcl,
 # *.vhd, *.vhdl, *.ucf, *.qsf, *.as and *.js.
 
-FILE_PATTERNS          = *.f90 *.f *.C *.c *.H *.h *.dox *.md
+FILE_PATTERNS          = *.f90 *.f *.C *.c *.H *.h *.dox
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.
@@ -847,10 +847,7 @@ EXCLUDE                = src/vpmSolver/dummyResStressModule.f90 \
                          src/vpmCommon/vpmLinAlg/feDataRoutines.f90 \
                          src/vpmCommon/vpmLinAlg/feLanczosModule.f90 \
                          src/vpmUtilities/sparseMatrixUtils.C \
-                         src/vpmUtilities/sparseMatrixInterface.f90 \
-                         src/vpmUtilities/sparseMatrixModule.f90 \
-                         src/vpmUtilities/diskMatrixModule.f90 \
-                         src/vpmUtilities/sDiskMatrixModule.f90
+                         src/vpmUtilities/sparseMatrixInterface.f90
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/src/vpmCommon/idTypeModule.f90
+++ b/src/vpmCommon/idTypeModule.f90
@@ -134,7 +134,7 @@ contains
     if (id%descr == '') then
        write(lpu,"(';')",advance=adv)
     else
-       write(lpu,601) trim(id%descr)
+       write(lpu,601,advance=adv) trim(id%descr)
     end if
 
 600 format('{"',a,'";')


### PR DESCRIPTION
Som users report that this DLL is needed as well.

The other two commits are unrelated, and fixes the doxygen input paths and a cosmetic newline in the frs-file header, respectively.